### PR TITLE
Remove unused guzzle library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "php": ">=5.4",
         "ext-curl": "*",
         "ext-json": "*",
-        "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "~6.0"
+        "ext-mbstring": "*"
     },
     "autoload": {
         "psr-4": { "RusticiSoftware\\Cloud\\V2\\" : "src/" }


### PR DESCRIPTION
Since guzzle library is causing conflict issues with new version and it is not used anywhere, it should be removed.