### PR TITLE
Support Guzzle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.8"
+        "guzzlehttp/guzzle": "^7.8 || ^8.0"
     },
     "autoload": {
         "psr-4": { "RusticiSoftware\\Cloud\\V2\\" : "src/" }


### PR DESCRIPTION
## Summary

- allow `guzzlehttp/guzzle ^8.0` while preserving `^7.8`
- require no generated-client changes after exercising the major HTTP request/response paths

Closes #33.

## Validation

Validated on PHP 8.5.9 with Composer 2.10.2.

### Guzzle 8

```sh
composer install --no-interaction --no-progress --prefer-dist
composer validate --strict --no-check-version
composer check-platform-reqs --no-dev
composer dump-autoload --optimize --strict-psr --no-interaction
composer audit --locked --no-interaction
```

- a lockless install selected `guzzlehttp/guzzle 8.0.1`, `guzzlehttp/promises 3.0.0`, and `guzzlehttp/psr7 3.0.0`
- 156 tracked PHP files passed syntax checks
- platform, optimized PSR-4 autoload, and advisory checks passed
- a concrete `GuzzleHttp\Client` + `MockHandler` smoke covered synchronous and asynchronous calls, 4xx exception translation, response deserialization, JSON model bodies, Basic auth, query construction, and multipart `SplFileObject` upload

### Guzzle 7

```sh
composer update \
  --with 'guzzlehttp/guzzle:^7.8' \
  --with-all-dependencies --no-interaction
```

- resolved `guzzlehttp/guzzle 7.15.2`
- the same comprehensive generated-client smoke passed

This repository does not currently contain an automated test suite, static-analysis dependency, Composer test script, or CI workflow. Strict Composer validation also retains the pre-existing warning for the fixed `version` field; validation passes when that unrelated check is omitted.